### PR TITLE
fix: bump kubectl-validate

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -10,7 +10,7 @@ require (
 	k8s.io/api v0.27.1
 	k8s.io/apiextensions-apiserver v0.27.1
 	k8s.io/apimachinery v0.27.1
-	sigs.k8s.io/kubectl-validate v0.0.0-20230510211825-5f4d23caa3af
+	sigs.k8s.io/kubectl-validate v0.0.0-20230511070719-4f427a78cb5e
 	sigs.k8s.io/yaml v1.3.0
 )
 

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -2426,10 +2426,8 @@ sigs.k8s.io/controller-runtime v0.14.6 h1:oxstGVvXGNnMvY7TAESYk+lzr6S3V5VFxQ6d92
 sigs.k8s.io/controller-runtime v0.14.6/go.mod h1:WqIdsAY6JBsjfc/CqO0CORmNtoCtE4S6qbPc9s68h+0=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd h1:EDPBXCAspyGV4jQlpZSudPeMmr1bNJefnuqLsRAsHZo=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd/go.mod h1:B8JuhiUyNFVKdsE8h686QcCxMaH6HrOAZj4vswFpcB0=
-sigs.k8s.io/kubectl-validate v0.0.0-20230510205115-4bf7cf3aa962 h1:w3P7n5vGuk789vETlnrC4BuuRvRWUeRjRePWvsdUt24=
-sigs.k8s.io/kubectl-validate v0.0.0-20230510205115-4bf7cf3aa962/go.mod h1:0+IwJWeQpDDO9xy0vra4TjfxO7bIeecLiv8CG6MgHRM=
-sigs.k8s.io/kubectl-validate v0.0.0-20230510211825-5f4d23caa3af h1:IyRXdOAipaGj6EybJrpfSdAi42OxXWdCtnVF1dRwtAA=
-sigs.k8s.io/kubectl-validate v0.0.0-20230510211825-5f4d23caa3af/go.mod h1:0+IwJWeQpDDO9xy0vra4TjfxO7bIeecLiv8CG6MgHRM=
+sigs.k8s.io/kubectl-validate v0.0.0-20230511070719-4f427a78cb5e h1:dl8eavwBZUmdt/fnsn35iLB9Pqvy+GWTU6bFAJZIybo=
+sigs.k8s.io/kubectl-validate v0.0.0-20230511070719-4f427a78cb5e/go.mod h1:0+IwJWeQpDDO9xy0vra4TjfxO7bIeecLiv8CG6MgHRM=
 sigs.k8s.io/kustomize/api v0.13.3 h1:JAICawjOKXVPppU/W46xrnRoFYp9vCyJ7UbIBqlQz7s=
 sigs.k8s.io/kustomize/api v0.13.3/go.mod h1:Bkaavz5RKK6ZzP0zgPrB7QbpbBJKiHuD3BB0KujY7Ls=
 sigs.k8s.io/kustomize/kyaml v0.14.2 h1:9WSwztbzwGszG1bZTziQUmVMrJccnyrLb5ZMKpJGvXw=


### PR DESCRIPTION
This PR bumps kubectl-validate (we need this fix https://github.com/kubernetes-sigs/kubectl-validate/pull/37)