### PR TITLE
feat: move UI under sub path

### DIFF
--- a/backend/main.go
+++ b/backend/main.go
@@ -37,7 +37,7 @@ func getOptions() options {
 func main() {
 	options := getOptions()
 	gin.SetMode(options.mode)
-	if config, err := config.NewContainer(options.kubeConfig); err != nil {
+	if config, err := config.New(options.kubeConfig); err != nil {
 		panic(err)
 	} else if server, err := server.New(config, options.log, options.sponsor); err != nil {
 		panic(err)

--- a/backend/pkg/config/config.go
+++ b/backend/pkg/config/config.go
@@ -24,7 +24,7 @@ type config struct {
 	cmResolver engineapi.ConfigmapResolver
 }
 
-func NewContainer(kubeConfig string) (Config, error) {
+func New(kubeConfig string) (Config, error) {
 	restConfig, err := utils.RestConfig(kubeConfig)
 	if err != nil {
 		return nil, err

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -10,8 +10,6 @@ import { registerPlugins } from '@/plugins'
 import clusterpolicy from './schemas/clusterpolicy.json'
 import context from './schemas/context.json'
 
-const baseURL = `${window.location.protocol}//${window.location.host}`
-
 setDiagnosticsOptions({
     enableSchemaRequest: true,
     hover: true,
@@ -19,8 +17,8 @@ setDiagnosticsOptions({
     validate: true,
     format: true,
     schemas: [
-        { ...clusterpolicy, uri: `${baseURL}/schemas/clusterpolicy.json`, fileMatch: ['policy.yaml'] },
-        { ...context, uri: `${baseURL}/schemas/context.json`, fileMatch: ['context.yaml'] }
+        { ...clusterpolicy, uri: `./schemas/clusterpolicy.json`, fileMatch: ['policy.yaml'] },
+        { ...context, uri: `./schemas/context.json`, fileMatch: ['context.yaml'] }
     ]
 });
 


### PR DESCRIPTION
This PR moves UI under `/ui` sub path:
- redirects user when connecting to `/`

Some things don't work (loading schemas) and some others work (shared links seem to work even with the redirect).