### PR TITLE
refactor: rename cluster routes

### DIFF
--- a/backend/pkg/server/api/cluster/routes.go
+++ b/backend/pkg/server/api/cluster/routes.go
@@ -29,7 +29,7 @@ func AddRoutes(group *gin.RouterGroup, cluster Cluster) error {
 		}
 		c.JSON(http.StatusOK, namespaces)
 	})
-	group.POST("/resources", func(c *gin.Context) {
+	group.POST("/search", func(c *gin.Context) {
 		var request SearchRequest
 		if err := c.ShouldBind(&request); err != nil {
 			c.String(http.StatusBadRequest, err.Error())

--- a/backend/pkg/server/api/routes.go
+++ b/backend/pkg/server/api/routes.go
@@ -13,7 +13,7 @@ func AddRoutes(group *gin.RouterGroup, config config.Config, cluster apicluster.
 		return err
 	}
 	if cluster != nil {
-		if err := apicluster.AddRoutes(group, cluster); err != nil {
+		if err := apicluster.AddRoutes(group.Group("/cluster"), cluster); err != nil {
 			return err
 		}
 	}

--- a/frontend/src/composables/api.ts
+++ b/frontend/src/composables/api.ts
@@ -84,11 +84,11 @@ const fetchWrapper = <T, R = undefined>(method: string, api: string, request: R)
     })
 }
 
-const fetchNamespaces = (api: string) => () => fetchWrapper<string[]>('GET', `${api}/namespaces`, undefined)
+const fetchNamespaces = (api: string) => () => fetchWrapper<string[]>('GET', `${api}/cluster/namespaces`, undefined)
 
-const fetchResources = (api: string) => (request: ListRequest) => fetchWrapper<{ namespace?: string, name: string }[], ListRequest>('POST', `${api}/resources`, request)
+const fetchResources = (api: string) => (request: ListRequest) => fetchWrapper<{ namespace?: string, name: string }[], ListRequest>('POST', `${api}/cluster/search`, request)
 
-const fetchResource = (api: string) => (request: ResourceRequest) => fetchWrapper<object, ResourceRequest>('POST', `${api}/resource`, request)
+const fetchResource = (api: string) => (request: ResourceRequest) => fetchWrapper<object, ResourceRequest>('POST', `${api}/cluster/resource`, request)
 
 export const useAPI = <T>() => {
     const api = resolveAPI()


### PR DESCRIPTION
This PR renames cluster routes:
- `/api/cluster/namespaces`
- `/api/cluster/search`
- `/api/cluster/resource`