### PR TITLE
fix: align cluster icon

### DIFF
--- a/frontend/src/components/Panel/ClusterPolicyButton.vue
+++ b/frontend/src/components/Panel/ClusterPolicyButton.vue
@@ -1,7 +1,11 @@
 <template>
   <v-dialog v-model="dialog" width="600px" :theme="layoutTheme">
     <template v-slot:activator="{ props }">
-      <v-btn v-bind="props" prepend-icon="mdi-kubernetes">Cluster</v-btn>
+      <v-tooltip location="bottom" content-class="no-opacity-tooltip" text="Import from Cluster" theme="dark">
+        <template v-slot:activator="{ props: tooltip }">
+          <v-btn v-bind="{ ...tooltip, ...props }" icon="mdi-kubernetes" />
+        </template>
+      </v-tooltip>
     </template>
 
     <v-card :theme="layoutTheme" title="Load from connected Cluster">

--- a/frontend/src/components/Panel/ClusterResourceButton.vue
+++ b/frontend/src/components/Panel/ClusterResourceButton.vue
@@ -1,7 +1,11 @@
 <template>
   <v-dialog v-model="dialog" width="600px" :theme="layoutTheme">
     <template v-slot:activator="{ props }">
-      <v-btn v-bind="props" prepend-icon="mdi-kubernetes">Cluster</v-btn>
+      <v-tooltip location="bottom" content-class="no-opacity-tooltip" text="Import from Cluster" theme="dark">
+        <template v-slot:activator="{ props: tooltip }">
+          <v-btn v-bind="{ ...tooltip, ...props }" icon="mdi-kubernetes" />
+        </template>
+      </v-tooltip>
     </template>
 
     <v-card :theme="layoutTheme" title="Load from connected Cluster">


### PR DESCRIPTION
align cluster icon with other toolbar icons (remove text and add tooltip)

<img width="343" alt="Bildschirmfoto 2023-05-22 um 12 15 45" src="https://github.com/kyverno/playground/assets/16627596/244407b3-bcfd-4311-be89-f03c32e098b3">
