### PR TITLE
fix: latest tag in prerelease

### DIFF
--- a/backend/.goreleaser.yaml
+++ b/backend/.goreleaser.yaml
@@ -19,7 +19,7 @@ kos:
   - repository: ghcr.io/kyverno/playground
     tags:
       - '{{.Tag}}'
-      - '{{ if not .Prerelease }}latest{{ end }}' 
+      - '{{ if not .Prerelease }}latest{{ else }}latest-prerelease{{ end }}' 
     bare: true
     preserve_import_paths: false
     sbom: none


### PR DESCRIPTION
Until https://github.com/goreleaser/goreleaser/pull/4043 lands in