### PR TITLE
fix: allow variable mockes in cluster fake mode

### DIFF
--- a/backend/pkg/cluster/cluster.go
+++ b/backend/pkg/cluster/cluster.go
@@ -37,6 +37,7 @@ type Cluster interface {
 	Get(context.Context, string, string, string, string) (*unstructured.Unstructured, error)
 	DClient(...unstructured.Unstructured) (dclient.Interface, error)
 	PolicyExceptionSelector(namespace string, exceptions ...*v2alpha1.PolicyException) engineapi.PolicyExceptionSelector
+	ContextLoaderFactory(cmResolver engineapi.ConfigmapResolver) engineapi.ContextLoaderFactory
 	IsFake() bool
 }
 
@@ -145,6 +146,10 @@ func (c cluster) PolicyExceptionSelector(namespace string, exceptions ...*v2alph
 
 func (c cluster) DClient(_ ...unstructured.Unstructured) (dclient.Interface, error) {
 	return c.dClient, nil
+}
+
+func (c cluster) ContextLoaderFactory(cmResolver engineapi.ConfigmapResolver) engineapi.ContextLoaderFactory {
+	return ContextLoaderFactory(c.IsFake(), cmResolver)
 }
 
 func (c cluster) IsFake() bool {

--- a/backend/pkg/cluster/contextloader.go
+++ b/backend/pkg/cluster/contextloader.go
@@ -1,0 +1,79 @@
+package cluster
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	kyvernov1 "github.com/kyverno/kyverno/api/kyverno/v1"
+	"github.com/kyverno/kyverno/cmd/cli/kubectl-kyverno/utils/store"
+	"github.com/kyverno/kyverno/pkg/clients/dclient"
+	engineapi "github.com/kyverno/kyverno/pkg/engine/api"
+	enginecontext "github.com/kyverno/kyverno/pkg/engine/context"
+	"github.com/kyverno/kyverno/pkg/engine/jmespath"
+	"github.com/kyverno/kyverno/pkg/logging"
+	"github.com/kyverno/kyverno/pkg/registryclient"
+)
+
+func ContextLoaderFactory(fake bool, cmResolver engineapi.ConfigmapResolver) engineapi.ContextLoaderFactory {
+	return func(policy kyvernov1.PolicyInterface, rule kyvernov1.Rule) engineapi.ContextLoader {
+		if fake {
+			return &fakeContextLoader{
+				logger:     logging.WithName("MockContextLoaderFactory"),
+				policyName: policy.GetName(),
+				ruleName:   rule.Name,
+			}
+		}
+
+		inner := engineapi.DefaultContextLoaderFactory(cmResolver)
+
+		return inner(policy, rule)
+	}
+}
+
+type fakeContextLoader struct {
+	cmResolver engineapi.ConfigmapResolver
+	logger     logr.Logger
+	policyName string
+	ruleName   string
+}
+
+func (l *fakeContextLoader) Load(
+	ctx context.Context,
+	jp jmespath.Interface,
+	_ dclient.Interface,
+	_ registryclient.Client,
+	contextEntries []kyvernov1.ContextEntry,
+	jsonContext enginecontext.Interface,
+) error {
+	rule := store.GetPolicyRule(l.policyName, l.ruleName)
+	if rule != nil && len(rule.Values) > 0 {
+		variables := rule.Values
+		for key, value := range variables {
+			if err := jsonContext.AddVariable(key, value); err != nil {
+				return err
+			}
+		}
+	}
+	for _, entry := range contextEntries {
+		if entry.ConfigMap != nil {
+			_ = engineapi.LoadConfigMap(ctx, l.logger, entry, jsonContext, l.cmResolver)
+		} else if entry.ImageRegistry != nil {
+			rclient := store.GetRegistryClient()
+			if err := engineapi.LoadImageData(ctx, jp, rclient, l.logger, entry, jsonContext); err != nil {
+				return err
+			}
+		} else if entry.Variable != nil {
+			if err := engineapi.LoadVariable(l.logger, jp, entry, jsonContext); err != nil {
+				return err
+			}
+		}
+	}
+	if rule != nil && len(rule.ForEachValues) > 0 {
+		for key, value := range rule.ForEachValues {
+			if err := jsonContext.AddVariable(key, value[store.GetForeachElement()]); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/backend/pkg/cluster/fake.go
+++ b/backend/pkg/cluster/fake.go
@@ -51,3 +51,7 @@ func (c fakeCluster) DClient(objects ...unstructured.Unstructured) (dclient.Inte
 func (c fakeCluster) IsFake() bool {
 	return true
 }
+
+func (c fakeCluster) ContextLoaderFactory(cmResolver engineapi.ConfigmapResolver) engineapi.ContextLoaderFactory {
+	return ContextLoaderFactory(c.IsFake(), cmResolver)
+}

--- a/backend/pkg/server/api/engine/handler.go
+++ b/backend/pkg/server/api/engine/handler.go
@@ -68,7 +68,7 @@ func newEngineHandler(cl cluster.Cluster, config APIConfiguration) (gin.HandlerF
 		if params.Flags.Exceptions.Enabled {
 			exceptionSelector = cl.PolicyExceptionSelector(params.Flags.Exceptions.Namespace, exceptions...)
 		}
-		processor, err := engine.NewProcessor(params, config, dClient, cmResolver, exceptionSelector)
+		processor, err := engine.NewProcessor(params, config, dClient, cl.ContextLoaderFactory(cmResolver), exceptionSelector)
 		if err != nil {
 			return nil, err
 		}

--- a/frontend/src/assets/templates.ts
+++ b/frontend/src/assets/templates.ts
@@ -58,7 +58,7 @@ metadata:
   name: kyverno
   namespace: kyverno
 data:
-  enableDefaultRegistryMutation: true
+  enableDefaultRegistryMutation: 'true'
   defaultRegistry: docker.io
   # comma separated list
   excludeGroups: 'system:nodes'
@@ -101,7 +101,7 @@ data:
     [Service,kyverno,kyverno-svc-metrics]
     [ServiceMonitor,kyverno,kyverno-svc-service-monitor]
     [Pod,kyverno,kyverno-test]`
-  
+
 export const CustomResourceDefinitionsTemplate = ``
 
 export const PolicyExceptionTemplate = `apiVersion: kyverno.io/v2alpha1

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -200,9 +200,7 @@ export const options = {
         },
         {
           name: 'ArgoCD',
-          policies: [
-            { path: 'argo/appproject-clusterresourceblacklist', title: 'Cluster resource blacklist' },
-          ]
+          policies: [{ path: 'argo/appproject-clusterresourceblacklist', title: 'Cluster resource blacklist' }]
         }
       ]
     },


### PR DESCRIPTION
With the introduction of fake clients we are using always the engineapi.ContextLoader which errors if an API Call is executed or a ConfigMap does not exist.

This PR adds the ContextLoaderFactory as Cluster method and returns a modified mock context loaders which tries to load a CM but ignores not found errors to fallback to mock variables.

APICalls are completely ignored and falls directly back to mock data.