### PR TITLE
Update Upload Icon Design in UploadButton Component

### DIFF
--- a/frontend/src/components/Panel/UploadButton.vue
+++ b/frontend/src/components/Panel/UploadButton.vue
@@ -10,26 +10,27 @@
       <v-btn
         v-bind="props"
         @click="select"
-        icon="mdi-upload"
         :loading="loading"
         :color="btnColor"
         :variant="variant"
         :width="width"
         :class="btnClass"
-      />
+      >
+        <svg-icon type="mdi" :path="path"></svg-icon>
+      </v-btn>
     </template>
   </v-tooltip>
   <v-btn
     v-else
     v-bind="props"
     @click="select"
-    prepend-icon="mdi-upload"
     :loading="loading"
     :color="btnColor"
     :variant="variant"
     :width="width"
     :class="btnClass"
   >
+    <svg-icon type="mdi" :path="path"></svg-icon>
     {{ label }}
   </v-btn>
 </template>
@@ -37,6 +38,8 @@
 <script setup lang="ts">
 import { type PropType } from 'vue'
 import { ref } from 'vue'
+import SvgIcon from '@jamescoyle/vue-icon'
+import { mdiFileDownload } from '@mdi/js'
 
 const props = defineProps({
   accept: { type: String, default: '.yaml,.yml,text/yaml,application/x-yaml' },
@@ -47,6 +50,8 @@ const props = defineProps({
   tooltip: { type: Boolean, default: true },
   btnClass: { type: String }
 })
+
+const path = mdiFileDownload
 
 const input = ref<HTMLInputElement | null>(null)
 


### PR DESCRIPTION
## Description
Modified the upload icon design in the UploadButton.vue component from a simple up-arrow to a more descriptive file-with-arrow icon, improving visual clarity for users.

## Changes Made
- Updated icon in `frontend/src/components/Panel/UploadButton.vue`
- Changed from a basic up-arrow icon to a file-with-arrow icon design
- Maintained the blue background color scheme

## Visual Changes

### Before
Before - Simple up-arrow icon on blue background

![Screenshot from 2025-01-09 18-23-36](https://github.com/user-attachments/assets/a7f30d9a-595c-411d-a68d-bf48571f6a34)

### After
After - File with down-arrow icon on blue background

![Screenshot from 2025-01-09 18-21-57](https://github.com/user-attachments/assets/7d01031e-8ca2-4af2-92d6-4ac192cfcb0b)

## Why this change?
Changed the upload button icon from a simple up-arrow to a file-with-arrow design to:

- Make the upload function more immediately recognizable
- Follow standard file operation UI patterns
- Improve visual clarity for users

## Impact
- More intuitive user experience
- Better visual communication
- No changes to functionality


## Additional Notes
- This is a purely visual change to improve user interface clarity
- No functional changes to the upload mechanism

Signed-off-by: Desh Deepak Kant <deshdeepakkant@gmail.com>