### PR TITLE
fix(ui): replace v-html with proper value escaping

### DIFF
--- a/frontend/src/components/ErrorBar.vue
+++ b/frontend/src/components/ErrorBar.vue
@@ -7,7 +7,7 @@
     :width="856"
     :timeout="-1"
   >
-    <span v-html="text" class="d-block" />
+    <span class="d-block">{{ text }}</span>
     <template v-slot:actions>
       <v-btn variant="text" @click="emit('update:modelValue', false)">Close</v-btn>
     </template>


### PR DESCRIPTION
Replace `v-html` in `ErrorBar.vue` with `{{ text }}` to use Vue's safe text interpolation, and switch `StartButton.vue` to build plain-text error messages instead of raw HTML strings so that policy metadata values are never treated as markup.