### PR TITLE
feat(api): add standalone CEL expression evaluation endpoint

### DIFF
--- a/backend/pkg/engine/cel/expr/env.go
+++ b/backend/pkg/engine/cel/expr/env.go
@@ -1,0 +1,137 @@
+package expr
+
+import (
+	"reflect"
+
+	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/ext"
+	"github.com/kyverno/kyverno/pkg/cel/compiler"
+	"github.com/kyverno/kyverno/pkg/cel/libs"
+	"github.com/kyverno/sdk/extensions/cel/libs/globalcontext"
+	"github.com/kyverno/sdk/extensions/cel/libs/gzip"
+	"github.com/kyverno/sdk/extensions/cel/libs/hash"
+	"github.com/kyverno/sdk/extensions/cel/libs/http"
+	"github.com/kyverno/sdk/extensions/cel/libs/image"
+	"github.com/kyverno/sdk/extensions/cel/libs/imagedata"
+	"github.com/kyverno/sdk/extensions/cel/libs/json"
+	"github.com/kyverno/sdk/extensions/cel/libs/math"
+	"github.com/kyverno/sdk/extensions/cel/libs/random"
+	"github.com/kyverno/sdk/extensions/cel/libs/resource"
+	"github.com/kyverno/sdk/extensions/cel/libs/time"
+	"github.com/kyverno/sdk/extensions/cel/libs/transform"
+	"github.com/kyverno/sdk/extensions/cel/libs/user"
+	"github.com/kyverno/sdk/extensions/cel/libs/x509"
+	"github.com/kyverno/sdk/extensions/cel/libs/yaml"
+	apiservercel "k8s.io/apiserver/pkg/cel"
+	"k8s.io/apiserver/pkg/cel/environment"
+)
+
+// newEnv builds a CEL environment for evaluating standalone expressions with
+// the same variables (object, oldObject, request, namespaceObject, variables)
+// and Kyverno CEL libraries (resource fetching, HTTP calls, global context,
+// image data, etc.) that a ValidatingPolicy would have available. It mirrors
+// the (unexported) environment construction in kyverno's
+// pkg/cel/policies/vpol/compiler package, since that logic isn't reusable
+// across module boundaries.
+func newEnv(libsctx libs.Context, namespace string) (*cel.Env, error) {
+	baseOpts := compiler.DefaultEnvOptionsWithCompat()
+	baseOpts = append(baseOpts,
+		cel.Variable(compiler.NamespaceObjectKey, compiler.NamespaceType.CelType()),
+		cel.Variable(compiler.ObjectKey, cel.DynType),
+		cel.Variable(compiler.OldObjectKey, cel.DynType),
+		cel.Variable(compiler.RequestKey, compiler.RequestType.CelType()),
+		cel.Types(compiler.NamespaceType.CelType()),
+		cel.Types(compiler.RequestType.CelType()),
+		cel.Variable(compiler.VariablesKey, compiler.VariablesType),
+	)
+
+	envSetVersion := compiler.KyvernoVersion
+	base := environment.MustBaseEnvSet(envSetVersion)
+	baseEnv, err := base.Env(environment.StoredExpressions)
+	if err != nil {
+		return nil, err
+	}
+
+	variablesProvider := compiler.NewVariablesProvider(baseEnv.CELTypeProvider())
+	declProvider := apiservercel.NewDeclTypeProvider(compiler.NamespaceType, compiler.RequestType)
+	declOptions, err := declProvider.EnvOptions(variablesProvider)
+	if err != nil {
+		return nil, err
+	}
+	baseOpts = append(baseOpts, declOptions...)
+
+	libEnvOpts := []cel.EnvOption{
+		ext.NativeTypes(reflect.TypeFor[libs.Exception](), ext.ParseStructTags(true)),
+		cel.Variable(compiler.ExceptionsKey, types.NewObjectType("libs.Exception")),
+		globalcontext.Lib(
+			globalcontext.Context{ContextInterface: libsctx},
+			globalcontext.Latest(),
+		),
+		resource.Lib(
+			resource.Context{ContextInterface: libsctx},
+			namespace,
+			resource.Latest(),
+		),
+		image.Lib(
+			image.Latest(),
+		),
+		imagedata.Lib(
+			imagedata.Context{ContextInterface: libsctx},
+			imagedata.Latest(),
+			nil,
+		),
+		user.Lib(
+			user.Latest(),
+		),
+		hash.Lib(
+			hash.Latest(),
+		),
+		math.Lib(
+			math.Latest(),
+		),
+		json.Lib(
+			&json.JsonImpl{},
+			json.Latest(),
+		),
+		yaml.Lib(
+			&yaml.YamlImpl{},
+			yaml.Latest(),
+		),
+		random.Lib(
+			random.Latest(),
+		),
+		x509.Lib(
+			x509.Latest(),
+		),
+		time.Lib(
+			time.Latest(),
+		),
+		transform.Lib(
+			transform.Latest(),
+		),
+		gzip.Lib(
+			gzip.Latest(),
+		),
+		http.Lib(
+			http.Context{ContextInterface: libs.NewMockAwareHTTPContext(compiler.NewLazyCELHTTPContext(namespace), libsctx.GetHTTPMocks())},
+			http.Latest(),
+		),
+	}
+
+	extendedBase, err := base.Extend(
+		environment.VersionedOptions{
+			IntroducedVersion: envSetVersion,
+			EnvOptions:        baseOpts,
+		},
+		environment.VersionedOptions{
+			IntroducedVersion: envSetVersion,
+			EnvOptions:        libEnvOpts,
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return extendedBase.Env(environment.StoredExpressions)
+}

--- a/backend/pkg/engine/cel/expr/evaluate.go
+++ b/backend/pkg/engine/cel/expr/evaluate.go
@@ -1,0 +1,107 @@
+package expr
+
+import (
+	"context"
+	gojson "encoding/json"
+	"fmt"
+	"reflect"
+
+	"github.com/kyverno/kyverno/pkg/cel/compiler"
+	"github.com/kyverno/kyverno/pkg/cel/libs"
+	sdkutils "github.com/kyverno/sdk/extensions/cel/utils"
+	"google.golang.org/protobuf/types/known/structpb"
+	admissionv1 "k8s.io/api/admission/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apiserver/pkg/cel/lazy"
+)
+
+// Result is the outcome of evaluating a standalone CEL expression. Exactly
+// one of Value or Error is set.
+type Result struct {
+	// Value is the JSON-serializable result of the expression.
+	Value any `json:"value,omitempty"`
+	// Type is the CEL type name of the result (e.g. "bool", "string", "list").
+	Type string `json:"type,omitempty"`
+	// Error is set when the expression failed to compile or evaluate.
+	Error string `json:"error,omitempty"`
+}
+
+// Input holds the variables a standalone CEL expression can reference,
+// matching what a ValidatingPolicy sees: object, oldObject, request and
+// namespaceObject.
+type Input struct {
+	Object          *unstructured.Unstructured
+	OldObject       *unstructured.Unstructured
+	Request         *admissionv1.AdmissionRequest
+	NamespaceObject *unstructured.Unstructured
+	Namespace       string
+}
+
+// Evaluate compiles and evaluates a standalone CEL expression against the
+// same variables and CEL libraries a Kyverno ValidatingPolicy has access to.
+// Compile and evaluation errors are returned inside Result rather than as a
+// Go error, so callers can render them next to the expression like any other
+// evaluation outcome; a non-nil error return indicates the environment
+// itself could not be constructed.
+func Evaluate(ctx context.Context, libsctx libs.Context, expression string, in Input) (*Result, error) {
+	env, err := newEnv(libsctx, in.Namespace)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build CEL environment: %w", err)
+	}
+
+	ast, issues := env.Compile(expression)
+	if err := issues.Err(); err != nil {
+		return &Result{Error: err.Error()}, nil
+	}
+
+	program, err := env.Program(ast)
+	if err != nil {
+		return &Result{Error: err.Error()}, nil
+	}
+
+	requestVal, err := sdkutils.ConvertObjectToUnstructured(in.Request)
+	if err != nil {
+		return nil, fmt.Errorf("failed to prepare request variable: %w", err)
+	}
+
+	data := map[string]any{
+		compiler.ObjectKey:          objectOrNil(in.Object),
+		compiler.OldObjectKey:       objectOrNil(in.OldObject),
+		compiler.RequestKey:         requestVal.Object,
+		compiler.NamespaceObjectKey: objectOrNil(in.NamespaceObject),
+		compiler.VariablesKey:       lazy.NewMapValue(compiler.VariablesType),
+		compiler.ExceptionsKey:      libs.Exception{AllowedImages: []string{}, AllowedValues: []string{}},
+	}
+
+	out, _, err := program.ContextEval(ctx, data)
+	if err != nil {
+		return &Result{Error: err.Error()}, nil
+	}
+
+	native, err := out.ConvertToNative(reflect.TypeOf(&structpb.Value{}))
+	if err != nil {
+		return &Result{Error: fmt.Sprintf("result could not be converted to JSON: %s", err)}, nil
+	}
+
+	raw, err := gojson.Marshal(native)
+	if err != nil {
+		return &Result{Error: fmt.Sprintf("result could not be marshalled to JSON: %s", err)}, nil
+	}
+
+	var value any
+	if err := gojson.Unmarshal(raw, &value); err != nil {
+		return &Result{Error: fmt.Sprintf("result could not be marshalled to JSON: %s", err)}, nil
+	}
+
+	return &Result{
+		Value: value,
+		Type:  out.Type().TypeName(),
+	}, nil
+}
+
+func objectOrNil(u *unstructured.Unstructured) any {
+	if u == nil {
+		return nil
+	}
+	return u.Object
+}

--- a/backend/pkg/engine/cel/expr/evaluate_test.go
+++ b/backend/pkg/engine/cel/expr/evaluate_test.go
@@ -1,0 +1,69 @@
+package expr
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kyverno/kyverno/pkg/cel/libs"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestEvaluate_Literal(t *testing.T) {
+	result, err := Evaluate(context.Background(), libs.NewFakeContextProvider(), "1 + 1", Input{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Error != "" {
+		t.Fatalf("unexpected evaluation error: %s", result.Error)
+	}
+	if result.Value != float64(2) {
+		t.Fatalf("expected 2, got %v (%T)", result.Value, result.Value)
+	}
+	if result.Type != "int" {
+		t.Fatalf("expected type int, got %s", result.Type)
+	}
+}
+
+func TestEvaluate_ObjectField(t *testing.T) {
+	object := &unstructured.Unstructured{Object: map[string]any{
+		"metadata": map[string]any{
+			"name": "my-pod",
+		},
+	}}
+
+	result, err := Evaluate(context.Background(), libs.NewFakeContextProvider(), "object.metadata.name", Input{Object: object})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Error != "" {
+		t.Fatalf("unexpected evaluation error: %s", result.Error)
+	}
+	if result.Value != "my-pod" {
+		t.Fatalf("expected my-pod, got %v", result.Value)
+	}
+}
+
+func TestEvaluate_CompileError(t *testing.T) {
+	result, err := Evaluate(context.Background(), libs.NewFakeContextProvider(), "object.metadata.", Input{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Error == "" {
+		t.Fatal("expected a compile error to be reported")
+	}
+}
+
+func TestEvaluate_KyvernoLibrary(t *testing.T) {
+	// exercises one of the Kyverno CEL libraries (math) to confirm the
+	// environment carries the same libraries a ValidatingPolicy would have.
+	result, err := Evaluate(context.Background(), libs.NewFakeContextProvider(), `math.round(3.14159, 2)`, Input{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Error != "" {
+		t.Fatalf("unexpected evaluation error: %s", result.Error)
+	}
+	if result.Value != 3.14 {
+		t.Fatalf("expected 3.14, got %v", result.Value)
+	}
+}

--- a/backend/pkg/server/api/cel/handler.go
+++ b/backend/pkg/server/api/cel/handler.go
@@ -1,0 +1,150 @@
+package cel
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	kyvernov1 "github.com/kyverno/kyverno/api/kyverno/v1"
+	"github.com/kyverno/kyverno/pkg/cel/libs"
+	gctxstore "github.com/kyverno/kyverno/pkg/globalcontext/store"
+	"github.com/loopfz/gadgeto/tonic"
+	admissionv1 "k8s.io/api/admission/v1"
+	authenticationv1 "k8s.io/api/authentication/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/yaml"
+
+	"github.com/kyverno/playground/backend/pkg/cluster"
+	"github.com/kyverno/playground/backend/pkg/engine/cel/expr"
+	"github.com/kyverno/playground/backend/pkg/engine/models"
+)
+
+// EvaluateRequest is the payload for evaluating a standalone CEL expression
+// against the same variables and libraries a ValidatingPolicy would have.
+type EvaluateRequest struct {
+	// Expression is the CEL expression to evaluate.
+	Expression string `json:"expression"`
+	// Resource is an optional YAML/JSON manifest bound to the `object` variable.
+	Resource string `json:"resource,omitempty"`
+	// OldResource is an optional YAML/JSON manifest bound to the `oldObject` variable.
+	OldResource string `json:"oldResource,omitempty"`
+	// NamespaceResource is an optional YAML/JSON Namespace manifest bound to the `namespaceObject` variable.
+	NamespaceResource string `json:"namespaceResource,omitempty"`
+	// Context carries the admission context (operation, user info, ...) used to build the `request` variable.
+	Context *models.Context `json:"context,omitempty"`
+}
+
+// EvaluateResponse is the outcome of evaluating a standalone CEL expression.
+// A failure to compile or evaluate the expression is reported in Error
+// rather than as an HTTP error, so it can be rendered next to the
+// expression like any other result.
+type EvaluateResponse struct {
+	Value any    `json:"value,omitempty"`
+	Type  string `json:"type,omitempty"`
+	Error string `json:"error,omitempty"`
+}
+
+func newHandler(cl cluster.Cluster) (gin.HandlerFunc, error) {
+	return tonic.Handler(func(ctx *gin.Context, in *EvaluateRequest) (*EvaluateResponse, error) {
+		resource, err := parseResource(in.Resource)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse resource: %w", err)
+		}
+		oldResource, err := parseResource(in.OldResource)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse oldResource: %w", err)
+		}
+		namespaceResource, err := parseResource(in.NamespaceResource)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse namespaceResource: %w", err)
+		}
+
+		admCtx := models.Context{Operation: kyvernov1.Create}
+		if in.Context != nil {
+			admCtx = *in.Context
+		}
+
+		dClient, err := cl.DClient(nil)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create client: %w", err)
+		}
+		contextProvider, err := libs.NewContextProvider(dClient, nil, gctxstore.New(0), cl.RESTMapper(nil), false)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create CEL library context: %w", err)
+		}
+
+		result, err := expr.Evaluate(ctx, contextProvider, in.Expression, expr.Input{
+			Object:          resource,
+			OldObject:       oldResource,
+			Request:         buildAdmissionRequest(resource, oldResource, admCtx),
+			NamespaceObject: namespaceResource,
+			Namespace:       resourceNamespace(resource, oldResource),
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		return &EvaluateResponse{Value: result.Value, Type: result.Type, Error: result.Error}, nil
+	}, http.StatusOK), nil
+}
+
+func parseResource(content string) (*unstructured.Unstructured, error) {
+	if strings.TrimSpace(content) == "" {
+		return nil, nil
+	}
+	var obj map[string]any
+	if err := yaml.Unmarshal([]byte(content), &obj); err != nil {
+		return nil, err
+	}
+	return &unstructured.Unstructured{Object: obj}, nil
+}
+
+func resourceNamespace(resources ...*unstructured.Unstructured) string {
+	for _, r := range resources {
+		if r != nil && r.GetNamespace() != "" {
+			return r.GetNamespace()
+		}
+	}
+	return ""
+}
+
+func buildAdmissionRequest(resource, oldResource *unstructured.Unstructured, admCtx models.Context) *admissionv1.AdmissionRequest {
+	primary := resource
+	if primary == nil {
+		primary = oldResource
+	}
+	if primary == nil {
+		primary = &unstructured.Unstructured{}
+	}
+	gvk := primary.GroupVersionKind()
+	gvr := gvk.GroupVersion().WithResource(strings.ToLower(gvk.Kind) + "s")
+
+	var newBytes, oldBytes []byte
+	if resource != nil {
+		newBytes, _ = resource.MarshalJSON()
+	}
+	if oldResource != nil {
+		oldBytes, _ = oldResource.MarshalJSON()
+	}
+
+	dryRun := admCtx.DryRun
+	return &admissionv1.AdmissionRequest{
+		UID:       "abc-123",
+		Kind:      metav1.GroupVersionKind(gvk),
+		Resource:  metav1.GroupVersionResource(gvr),
+		Name:      primary.GetName(),
+		Namespace: primary.GetNamespace(),
+		Operation: admissionv1.Operation(admCtx.Operation),
+		UserInfo: authenticationv1.UserInfo{
+			UID:      "user-123",
+			Username: admCtx.Username,
+			Groups:   admCtx.Groups,
+		},
+		Object:    runtime.RawExtension{Raw: newBytes},
+		OldObject: runtime.RawExtension{Raw: oldBytes},
+		DryRun:    &dryRun,
+	}
+}

--- a/backend/pkg/server/api/cel/routes.go
+++ b/backend/pkg/server/api/cel/routes.go
@@ -1,0 +1,16 @@
+package cel
+
+import (
+	"github.com/gin-gonic/gin"
+
+	"github.com/kyverno/playground/backend/pkg/cluster"
+)
+
+func AddRoutes(group *gin.RouterGroup, cluster cluster.Cluster) error {
+	handler, err := newHandler(cluster)
+	if err != nil {
+		return err
+	}
+	group.POST("/cel", handler)
+	return nil
+}

--- a/backend/pkg/server/api/routes.go
+++ b/backend/pkg/server/api/routes.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/kyverno/playground/backend/pkg/cluster"
 	"github.com/kyverno/playground/backend/pkg/crd"
+	apicel "github.com/kyverno/playground/backend/pkg/server/api/cel"
 	apicluster "github.com/kyverno/playground/backend/pkg/server/api/cluster"
 	apiconfig "github.com/kyverno/playground/backend/pkg/server/api/config"
 	apiengine "github.com/kyverno/playground/backend/pkg/server/api/engine"
@@ -25,6 +26,9 @@ func AddRoutes(group *gin.RouterGroup, cluster cluster.Cluster, config APIConfig
 		return err
 	}
 	if err := apiengine.AddRoutes(group, cluster, config.EngineConfiguration); err != nil {
+		return err
+	}
+	if err := apicel.AddRoutes(group, cluster); err != nil {
 		return err
 	}
 	// do not register cluster routes if we don't have a cluster

--- a/frontend/src/components/AppBar/MobileMenu.vue
+++ b/frontend/src/components/AppBar/MobileMenu.vue
@@ -5,6 +5,10 @@
     </template>
     <v-card min-width="250">
       <v-card-text>
+        <v-btn to="/cel" prepend-icon="mdi-function-variant" variant="outlined" block>
+          CEL Playground
+        </v-btn>
+        <v-divider class="my-2" />
         <ShareButton variant="outlined" block />
         <v-divider class="my-2" />
         <SaveButton variant="outlined" block />

--- a/frontend/src/composables/cel.ts
+++ b/frontend/src/composables/cel.ts
@@ -1,0 +1,38 @@
+import { resolveAPI } from '@/utils'
+import type { CelEvaluateResponse } from '@/types'
+
+export type CelEvaluateRequest = {
+  expression: string
+  resource?: string
+  oldResource?: string
+  namespaceResource?: string
+  context?: {
+    operation?: string
+    username?: string
+    groups?: string[]
+  }
+}
+
+export const useCelAPI = () => {
+  const api = resolveAPI()
+
+  const evaluate = (request: CelEvaluateRequest): Promise<CelEvaluateResponse> => {
+    return fetch(`${api}/cel`, {
+      method: 'POST',
+      mode: 'cors',
+      cache: 'no-cache',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(request),
+    }).then(async (resp) => {
+      if (resp.status > 200) {
+        throw new Error(await resp.text())
+      }
+
+      return resp.json()
+    })
+  }
+
+  return { evaluate }
+}

--- a/frontend/src/pages/CelPlayground.vue
+++ b/frontend/src/pages/CelPlayground.vue
@@ -1,0 +1,268 @@
+<template>
+  <v-app :theme="layoutTheme">
+    <AppBar>
+      <template #append-actions>
+        <v-btn to="/" prepend-icon="mdi-arrow-left" class="d-md-flex d-none">Back to Playground</v-btn>
+      </template>
+      <template #mobile-actions>
+        <v-btn to="/" icon="mdi-arrow-left" />
+      </template>
+    </AppBar>
+    <v-main>
+      <v-container fluid class="pr-lg-4 pr-md-4 pr-sm-8 pr-8">
+        <v-row>
+          <v-col :md="6" :sm="12">
+            <v-card>
+              <v-toolbar color="#3783c4" theme="dark" density="compact" flat>
+                <v-toolbar-title>Expression</v-toolbar-title>
+                <v-toolbar-items>
+                  <CopyButton :value="expression" />
+                </v-toolbar-items>
+              </v-toolbar>
+              <MonacoEditor
+                id="cel-expression"
+                language="plaintext"
+                :theme="editorTheme"
+                v-model="expression"
+                :options="expressionOptions"
+                style="height: 120px"
+              />
+            </v-card>
+
+            <v-card class="mt-4">
+              <EditorToolbar title="Resource" info="Bound to the `object` CEL variable" v-model="resource">
+                <template #prepend-actions>
+                  <TemplateButton @select="(template: string) => (resource = template)" />
+                </template>
+              </EditorToolbar>
+              <MonacoEditor
+                id="cel-resource"
+                language="yaml"
+                :theme="editorTheme"
+                v-model="resource"
+                :options="resourceOptions"
+                :uri="resourceUri"
+                style="height: 280px"
+              />
+            </v-card>
+
+            <v-card class="mt-4">
+              <EditorToolbar
+                title="Old Resource"
+                info="Bound to the `oldObject` CEL variable"
+                v-model="oldResource"
+              >
+                <template #append-actions>
+                  <v-btn :icon="collapseOld ? 'mdi-chevron-down' : 'mdi-chevron-up'" @click="collapseOld = !collapseOld" />
+                </template>
+              </EditorToolbar>
+              <MonacoEditor
+                id="cel-old-resource"
+                language="yaml"
+                :theme="editorTheme"
+                v-model="oldResource"
+                :options="resourceOptions"
+                :uri="oldResourceUri"
+                style="height: 200px"
+                v-show="!collapseOld"
+              />
+            </v-card>
+
+            <v-card class="mt-4">
+              <v-toolbar color="#3783c4" theme="dark" density="compact" flat>
+                <v-toolbar-title>
+                  Context
+                  <v-tooltip
+                    text="Used to build the `request` CEL variable"
+                    content-class="no-opacity-tooltip"
+                  >
+                    <template v-slot:activator="{ props }">
+                      <v-btn v-bind="props" icon="mdi-information-outline" variant="text" size="small" />
+                    </template>
+                  </v-tooltip>
+                </v-toolbar-title>
+                <v-toolbar-items>
+                  <v-btn :icon="collapseContext ? 'mdi-chevron-down' : 'mdi-chevron-up'" @click="collapseContext = !collapseContext" />
+                </v-toolbar-items>
+              </v-toolbar>
+              <v-card-text v-show="!collapseContext">
+                <v-row>
+                  <v-col cols="12" sm="6">
+                    <v-select
+                      label="Operation"
+                      :items="operations"
+                      v-model="operation"
+                      variant="outlined"
+                      density="comfortable"
+                      hide-details
+                    />
+                  </v-col>
+                  <v-col cols="12" sm="6">
+                    <v-text-field
+                      label="Username"
+                      v-model="username"
+                      variant="outlined"
+                      density="comfortable"
+                      hide-details
+                    />
+                  </v-col>
+                  <v-col cols="12">
+                    <v-text-field
+                      label="Groups (comma separated)"
+                      v-model="groupsInput"
+                      variant="outlined"
+                      density="comfortable"
+                      hide-details
+                    />
+                  </v-col>
+                </v-row>
+              </v-card-text>
+            </v-card>
+          </v-col>
+
+          <v-col :md="6" :sm="12">
+            <v-card>
+              <v-toolbar color="#3783c4" theme="dark" density="compact" flat>
+                <v-toolbar-title>Result</v-toolbar-title>
+                <v-toolbar-items v-if="result?.type">
+                  <v-chip class="align-self-center mr-4" size="small" color="white" variant="outlined">
+                    {{ result.type }}
+                  </v-chip>
+                </v-toolbar-items>
+              </v-toolbar>
+              <v-card-text>
+                <v-alert v-if="error" type="error" variant="tonal" class="mb-0">{{ error }}</v-alert>
+                <v-alert v-else-if="result?.error" type="warning" variant="tonal" class="mb-0">
+                  {{ result.error }}
+                </v-alert>
+                <pre v-else-if="result" class="result-value">{{ formattedValue }}</pre>
+                <div v-else class="text-medium-emphasis pa-4">
+                  Evaluate an expression to see its result here.
+                </div>
+              </v-card-text>
+            </v-card>
+          </v-col>
+        </v-row>
+
+        <v-btn
+          id="evaluate-btn"
+          size="large"
+          prepend-icon="mdi-play"
+          color="primary"
+          class="evaluate"
+          rounded
+          :loading="loading"
+          @click="submit"
+        >
+          Evaluate
+        </v-btn>
+      </v-container>
+    </v-main>
+  </v-app>
+</template>
+
+<script setup lang="ts">
+import { ref, computed } from 'vue'
+import { Uri } from 'monaco-editor'
+import { editorTheme, layoutTheme } from '@/config'
+import { AppBar } from '@/components/AppBar'
+import MonacoEditor from '@/components/Panel/MonacoEditor.vue'
+import EditorToolbar from '@/components/Panel/EditorToolbar.vue'
+import CopyButton from '@/components/Panel/CopyButton.vue'
+import TemplateButton from '@/components/Panel/TemplateButton.vue'
+import { useCelAPI } from '@/composables/cel'
+import type { CelEvaluateResponse } from '@/types'
+
+const expression = ref<string>('')
+const resource = ref<string>('')
+const oldResource = ref<string>('')
+const collapseOld = ref<boolean>(true)
+const collapseContext = ref<boolean>(true)
+
+const operations = ['CREATE', 'UPDATE', 'DELETE', 'CONNECT']
+const operation = ref<string>('CREATE')
+const username = ref<string>('')
+const groupsInput = ref<string>('')
+
+const expressionOptions = {
+  colorDecorators: true,
+  lineHeight: 24,
+  tabSize: 2,
+  minimap: { enabled: false },
+  lineNumbers: 'off' as const,
+}
+
+// Distinct URIs from the Home page's `resource.yaml` model (see ResourceEditor.vue) -
+// Monaco models are looked up globally by URI, so reusing that URI here would bind
+// this editor to whatever content the Home page's resource editor last held.
+const resourceUri = Uri.parse('cel-resource.yaml')
+const oldResourceUri = Uri.parse('cel-old-resource.yaml')
+const resourceOptions = {
+  colorDecorators: true,
+  lineHeight: 24,
+  tabSize: 2,
+}
+
+const { evaluate } = useCelAPI()
+
+const loading = ref<boolean>(false)
+const result = ref<CelEvaluateResponse>()
+const error = ref<string>('')
+
+const formattedValue = computed(() => {
+  if (result.value?.value === undefined) return ''
+  return JSON.stringify(result.value.value, null, 2)
+})
+
+const submit = () => {
+  if (!expression.value.trim()) {
+    error.value = 'Expression is required'
+    result.value = undefined
+    return
+  }
+
+  error.value = ''
+  loading.value = true
+
+  const groups = groupsInput.value
+    .split(',')
+    .map((g) => g.trim())
+    .filter((g) => !!g)
+
+  evaluate({
+    expression: expression.value,
+    resource: resource.value,
+    oldResource: oldResource.value,
+    context: {
+      operation: operation.value,
+      username: username.value,
+      groups,
+    },
+  })
+    .then((resp) => {
+      result.value = resp
+    })
+    .catch((err: Error) => {
+      error.value = err.message
+      result.value = undefined
+    })
+    .finally(() => {
+      loading.value = false
+    })
+}
+</script>
+
+<style scoped>
+.evaluate {
+  position: fixed;
+  bottom: 45px;
+  right: 50px;
+}
+
+.result-value {
+  white-space: pre-wrap;
+  word-break: break-word;
+  font-family: monospace;
+  margin: 0;
+}
+</style>

--- a/frontend/src/pages/Home.vue
+++ b/frontend/src/pages/Home.vue
@@ -12,6 +12,7 @@
       </template>
       <template #desktop-actions>
         <PrimeButton @click="start" v-if="onboarding" variant="outlined">Onboarding</PrimeButton>
+        <v-btn to="/cel" prepend-icon="mdi-function-variant" class="ml-2">CEL Playground</v-btn>
         <ShareButton btn-class="ml-2" />
         <SaveButton btn-class="ml-2" />
         <LoadButton btn-class="mx-2" />

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -1,6 +1,7 @@
 import Home from '@/pages/Home.vue'
 import MutationDetails from '@/pages/MutationDetails.vue'
 import GenerationDetails from '@/pages/GenerationDetails.vue'
+import CelPlayground from '@/pages/CelPlayground.vue'
 import { type RouteRecordRaw, createRouter, createWebHashHistory } from 'vue-router'
 
 const routes: RouteRecordRaw[] = [
@@ -13,6 +14,11 @@ const routes: RouteRecordRaw[] = [
     path: '/generation/:id',
     component: GenerationDetails,
     name: 'generation-details',
+  },
+  {
+    path: '/cel',
+    component: CelPlayground,
+    name: 'cel-playground',
   },
   {
     path: '/',

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -82,3 +82,9 @@ export type EngineResponse = {
   imageVerification?: Mutation[]
   generation?: Generation[]
 }
+
+export type CelEvaluateResponse = {
+  value?: unknown
+  type?: string
+  error?: string
+}


### PR DESCRIPTION
## Summary

Adds standalone CEL expression evaluation to the playground, end to end:

- **Backend**: `POST /api/cel` compiles and evaluates a single CEL expression using the same variables (`object`, `oldObject`, `request`, `namespaceObject`) and Kyverno CEL libraries (resource fetching, HTTP calls, global context, image data, hashing, JSON/YAML, x509, time, transform, etc.) that a `ValidatingPolicy` has access to.
- **Frontend**: a new `/cel` page ("CEL Playground", linked from the app bar) with an expression editor, resource/old-resource editors, an admission-context form, and a result panel showing the value, its CEL type, or the compile/eval error.

This started as a draft to get early feedback on the API shape before investing in the frontend (see the earlier draft description below); the frontend is now built and tested against that shape, so I'm marking it ready for review. Happy to adjust either side if the shape should change.

## Screenshots

The entry point: a "CEL Playground" item in the app bar.

![Home page app bar](https://raw.githubusercontent.com/rupeshkumar92a-arch/playground/assets/cel-playground-screenshots/cel-playground/0-home-appbar-link.png)

The page itself (`/#/cel`).

![Empty CEL Playground page](https://raw.githubusercontent.com/rupeshkumar92a-arch/playground/assets/cel-playground-screenshots/cel-playground/1-cel-empty.png)

A standalone expression, no resource needed — the chip in the Result toolbar is the CEL type of the value.

![Literal expression evaluated](https://raw.githubusercontent.com/rupeshkumar92a-arch/playground/assets/cel-playground-screenshots/cel-playground/2-literal.png)

Against a submitted resource — the manifest in the Resource editor is bound to `object`.

![Object field access](https://raw.githubusercontent.com/rupeshkumar92a-arch/playground/assets/cel-playground-screenshots/cel-playground/3-object-access.png)

Structured results are rendered as formatted JSON.

![List result](https://raw.githubusercontent.com/rupeshkumar92a-arch/playground/assets/cel-playground-screenshots/cel-playground/4-structured-result.png)

Admission context — operation / username / groups build the `request` variable.

![Request context](https://raw.githubusercontent.com/rupeshkumar92a-arch/playground/assets/cel-playground-screenshots/cel-playground/5-request-context.png)

Compile errors are rendered inline in the result panel rather than surfaced as an HTTP error.

![Compile error](https://raw.githubusercontent.com/rupeshkumar92a-arch/playground/assets/cel-playground-screenshots/cel-playground/6-compile-error.png)

## Design

- `pkg/engine/cel/expr` (backend): builds the CEL environment and evaluates the expression. The environment construction mirrors kyverno's own (unexported) `pkg/cel/policies/vpol/compiler` setup — same base env options, same variable declarations, same library set — since that logic isn't exported for reuse across module boundaries. This is consistent with how kyverno's own `dpol`/`gpol`/`mpol`/`ivpol` compilers each define their own base environment rather than sharing one.
- `pkg/server/api/cel` (backend): the gin/tonic HTTP handler, following the same pattern as the existing `pkg/server/api/engine` handler. Compile and evaluation errors are returned inside the response body (`error` field) rather than as HTTP errors, so the frontend renders them inline next to the expression like any other result.
- The CEL result is converted to a JSON-serializable value via the `structpb.Value` round-trip, matching the conversion pattern already used elsewhere in kyverno (e.g. `pkg/cel/policies/mpol/compiler/json.go`).
- `src/pages/CelPlayground.vue` (frontend): a self-contained page rather than folding into the existing Home.vue policy/resource flow, since that flow's save/share/URL-encoding state model is built specifically around "policy + resource" and evaluating one expression is a different shape. The Resource/Old Resource editors use their own Monaco model URIs (`cel-resource.yaml` / `cel-old-resource.yaml`) instead of `ResourceEditor.vue`'s hardcoded `resource.yaml` — reusing that component as-is caused this page to inherit whatever content the Home page's resource editor last held, since Monaco looks up models globally by URI. Found and fixed this via a Playwright-driven smoke test navigating Home → `/cel`.

## Known v1 scope limitation

`resource.Get()` / `http.Get()` and the other CEL libraries are present and functional in the environment, but currently run against an empty/fake client, so they'll resolve to not-found/empty rather than real data. Wiring this endpoint up to accept `clusterResources` and seed a real `dclient.Interface` (mirroring how the existing `/api/engine` endpoint does it) is a natural, self-contained follow-up.

## Test plan

- [x] `go build ./pkg/engine/cel/expr/... ./pkg/server/api/...`
- [x] `go test ./pkg/engine/cel/expr/...` — literal evaluation, object field access, compile-error reporting, one of the Kyverno CEL libraries (`math.round`)
- [x] `go test ./pkg/server/api/engine/... ./pkg/playground/...` (existing suites) — confirms nothing else regressed
- [x] `vue-tsc --build` and `vite build` — frontend typechecks and builds cleanly
- [x] Ran the built backend + frontend locally and drove it with Playwright: literal expression evaluation (`1 + 1` → `2`, type `int`), object field access against a submitted resource (`object.metadata.name`), compile-error rendering, and nav-then-evaluate from the Home page — all confirmed working via screenshots, with no new console errors beyond a pre-existing Monaco worker warning already present on the unmodified Home page

